### PR TITLE
Impostor backend: Add Host Change event

### DIFF
--- a/src/backends/ImpostorBackend.ts
+++ b/src/backends/ImpostorBackend.ts
@@ -27,6 +27,10 @@ export default class ImpostorBackend extends BackendAdapter {
             this.connection = new HubConnectionBuilder()
                 .withUrl(`http://${this.backendModel.ip}:${IMPOSTOR_BACKEND_PORT}/hub`).build();
 
+            this.connection.on(ImpostorSocketEvents.HostChange, (name: string) => {
+                this.emitHostChange(name);
+            });
+
             this.connection.on(ImpostorSocketEvents.MapChange, (id: number) => {
                 this.emitMapChange(id);
             });
@@ -76,6 +80,7 @@ export default class ImpostorBackend extends BackendAdapter {
 
 export enum ImpostorSocketEvents {
     TrackGame = "TrackGame",
+    HostChange = "HostChange",
     MapChange = "MapChange",
     GameStarted = "GameStarted",
     PlayerMove = "PlayerMove",


### PR DESCRIPTION
This makes it possible to edit the host setting on Impostor-based games

This change needs a change on the Impostor side too, which can be found here: https://github.com/edqx/Impostor/pull/1

With respect to backwards compatibility: when the event is not emitted by an outdated server plugin, nothing happens. I have not tested the other way around (new plugin, old AUProximity)